### PR TITLE
Makes sure the socket plugin's thread is only started on loading of p…

### DIFF
--- a/plugins/socket/__init__.py
+++ b/plugins/socket/__init__.py
@@ -29,6 +29,8 @@ def run_socket_server():
 
     socketio.run(app, host="0.0.0.0", port=8000, debug=False, use_reloader=False, log_output=False)
 
-WEB_THREAD = Thread(target=run_socket_server)
-WEB_THREAD.daemon = True
-WEB_THREAD.start()
+# prevent starting the thread already on imports
+if __name__ == "__init__":
+    SOCKET_THREAD = Thread(target=run_socket_server)
+    SOCKET_THREAD.daemon = True
+    SOCKET_THREAD.start()


### PR DESCRIPTION
### Short Description: 
Added a guard that prevents the socket plugin from multiple threads (leading to 'address already in use') being started.
### Changes:
-  Makes sure the socket plugin's thread is only started on loading of plugin
@OpenPoGo/maintainers

Without the guard the thread is started for every import of the plugin.